### PR TITLE
Fixed resub month count

### DIFF
--- a/src/lib/TwitchBot.js
+++ b/src/lib/TwitchBot.js
@@ -333,7 +333,7 @@ class TwitchBot {
    * @return {[none]} [description]
    */
   ResubAlert() {
-    this._client.on('resub', (channel, username, months, message) => {
+    this._client.on('resub', (channel, username, streakMonths, message, userstate) => {
       if (Config.enableCustomMessages) {
         const resubAlertMessages =
           Config.customMessages[channel].resubscriptions;
@@ -345,6 +345,7 @@ class TwitchBot {
               this._messagesCount[channel].resubscriptions
             );
           }
+          const months = parseInt(userstate["msg-param-cumulative-months"])
           const alert = resubAlertMessages[`custom${rand}`];
           const years = Math.floor(months / 12);
           const yearMonths = months % 12;


### PR DESCRIPTION
After looking at the changes to tmi.js and a friend. I noticed that the months param has been deprecated with streakMonths which isn't good enough for people who don't share streaks. So we take the userstate, get all the months they've been subbed, turn it to an int and change months to that. Tested on my end and works flawlessly.